### PR TITLE
Fix regular expressions escaping in a workflow

### DIFF
--- a/.github/workflows/2-add-a-job.yml
+++ b/.github/workflows/2-add-a-job.yml
@@ -61,7 +61,7 @@ jobs:
         uses: skills/action-check-file@v1
         with:
           file: ".github/workflows/my-starter-workflow.yml"
-          search: "uses: ./.github/workflows/reusable-workflow.yml"
+          search: "uses: \\./\\.github/workflows/reusable-workflow\\.yml"
 
       # In README.md, switch step 2 for step 3.
       - name: Update to step 3


### PR DESCRIPTION
Escape `.` to `\\.`

### Summary
<!-- A clear and concise description of what the problem or opportunity is. -->
Fix regular expressions escaping in a workflow

### Changes
<!-- Describe the changes this pull request introduces. -->
`.` &rarr; `\\.`

<!-- If there's an existing issue for your change, please link to it below next to "Closes".
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted. -->

### Task list

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
